### PR TITLE
fixed set-debug: pass vector to assoc-sm

### DIFF
--- a/src/waltz/state.cljs
+++ b/src/waltz/state.cljs
@@ -106,4 +106,4 @@
         (debug-log sm "(trans " (str trans) ") -> " (boolean res) " :: context " (pr-str context))))))
 
 (defn set-debug [sm dbg]
-  (assoc-sm sm :debug dbg))
+  (assoc-sm sm [:debug] dbg))


### PR DESCRIPTION
Here's a small fix. Nice work!

\- Felix
