### PR TITLE
set-debug broken

### DIFF
--- a/src/waltz/state.cljs
+++ b/src/waltz/state.cljs
@@ -106,4 +106,4 @@
         (debug-log sm "(trans " (str trans) ") -> " (boolean res) " :: context " (pr-str context))))))
 
 (defn set-debug [sm dbg]
-  (assoc-sm sm :debug dbg))
+  (assoc-sm sm [:debug] dbg))


### PR DESCRIPTION
set-debug needs to wrap :debug in a vector.

``` clojure
(defn set-debug [sm dbg]
  (assoc-sm sm :debug dbg))
```

=>

``` clojure
(defn set-debug [sm dbg]
  (assoc-sm sm [:debug] dbg))
```
